### PR TITLE
Added CLI Integration Globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const readline = require('readline');
 const executeQuery = require('./src/wrapper');
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.7",
   "description": "A lightweight and minimal csv database package",
   "main": "index.js",
+  "bin": {
+  "kaizer-db": "./index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DarkMortal/Kaizer-DB/"


### PR DESCRIPTION
Closes #4 

### **Issue Description**
The Kaizer-DB package required users to create a separate file to utilize its functionalities. The goal was to enable direct usage of the package from the command line, improving usability for developers and end users.

---

### **How to Test Locally**

#### **Link the Package Locally**  
Run the following command in the project directory:

```bash
npm link
```

#### **Test the CLI**  
Run the command:

```bash
kaizer-db
```

Execute various queries and ensure the functionality works as expected.

---

### **How to Install Globally**

#### **Install Globally**  
Users can install the package globally with:

```bash
npm install -g kaizer-db
```

#### **Use the CLI**  
Once installed, the `kaizer-db` command will be globally available.  
Example:

```bash
kaizer-db
```

---

### **Video**
---

https://github.com/user-attachments/assets/af49fd3b-1888-40e0-8fdd-b676de5b7e6a


